### PR TITLE
Added a reference to time credits to Dynamic Backends.

### DIFF
--- a/transformations/python-plain/index.md
+++ b/transformations/python-plain/index.md
@@ -91,7 +91,7 @@ To speed it up, you can change the backend size in the configuration. Python tra
 {: .image-popup}
 ![Screenshot - Backend size configuration](/transformations/python-plain/backend-size.png)
 
-Scaling up the backend size allocates more resources to speed up your transformation.
+Scaling up the backend size allocates more resources to speed up your transformation, which impacts [time credits consumption](/management/project/limits/#project-power--time-credits).
 
 ***Note:** Dynamic backends are not available to you if you are on the [Free Plan (Pay As You Go)](/management/payg-project/).*
 


### PR DESCRIPTION
It is fair to refer to a change in credits spent when changing dynamic backend size. Added one sentence.

